### PR TITLE
Fix file_tree when configuring minions as a list instead of a compoun…

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -490,8 +490,8 @@ def _ext_pillar(
             for nodegroup in ext_pillar_dirs:
                 if os.path.isdir(nodegroups_dir) and nodegroup in master_ngroups:
                     ckminions = salt.utils.minions.CkMinions(__opts__)
-                    _res = ckminions.check_minions(
-                        master_ngroups[nodegroup], "compound"
+                    _res = ckminions._check_nodegroup_minions(
+                        nodegroup, greedy=True
                     )
                     match = _res["minions"]
                     if minion_id in match:


### PR DESCRIPTION
…d matcher. ##61607

### What does this PR do?
Fix file_tree when nodegroups in master are defined as lists instead of compound matcher.

### What issues does this PR fix or reference?
Fixes: #61607

### Previous Behavior
```
nodegroups:
  NG1:
    - minion1
    - minion2
  NG2:
    - minion3
    - minion4

[ERROR ] ["Invalid compound target: ['minion1', 'minion2', 'minion3', 'minion4']"]

```
### New Behavior
Nodegroup membership is evaluated accordingly.

### Merge requirements satisfied?
Tested that files matching different nodegroups are then served with different nodegroups definitions like:

```
nodegroups:
  NG1: G@os:Debian and N@NG2
  NG2: L@minion1,minion2

```
or

```
nodegroups:
  NG1:
    - minion1
    - minion2
  NG2:
    - minion3
    - minion4
```
### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
